### PR TITLE
Fix infinite maxUnits bug in ship design

### DIFF
--- a/SpaceTrader/Design2VC.swift
+++ b/SpaceTrader/Design2VC.swift
@@ -92,6 +92,11 @@ class Design2VC: UIViewController {
                 maxUnits = 250
         }
         
+        // handle size specialty. If selected size is specialty, player gets 20 more units to work with
+        if player.selectedConstructShipSize == galaxy.currentSystem!.shipyardSizeSpecialty {
+            maxUnits += 20
+        }
+        
         // set defaults, load display
         self.setMaxMinDefault()
         self.updateDisplay()
@@ -285,11 +290,6 @@ class Design2VC: UIViewController {
                 unitsInUse -= 40
             default:
                 print("error")
-        }
-        
-        // handle size specialty. If selected size is specialty, player gets 20 more units to work with
-        if player.selectedConstructShipSize == galaxy.currentSystem!.shipyardSizeSpecialty {
-            maxUnits += 20
         }
     }
     


### PR DESCRIPTION
Move size speciality handler from updateDisplay() to viewDidLoad() to prevent maxUnits from increasing by 20 every time a button is tapped

Fixes #1